### PR TITLE
make time unit test more reliable

### DIFF
--- a/pkg/utils/time_utils_test.go
+++ b/pkg/utils/time_utils_test.go
@@ -12,11 +12,11 @@ func TestClock(t *testing.T) {
 	t1 := time.Now()
 	t2 := clk.Now()
 
-	assert.True(t, t2.After(t1))
+	assert.True(t, t2.Compare(t1) >= 0)
 
 	clk.Sleep(10 * time.Millisecond)
 
-	assert.True(t, clk.Now().Sub(t2) > 10*time.Millisecond)
+	assert.True(t, clk.Now().Sub(t2) >= 10*time.Millisecond)
 }
 
 func TestTicket(t *testing.T) {


### PR DESCRIPTION
When running the unit tests on a Windows machine, I see the failure

--- FAIL: TestClock (0.01s)
    time_utils_test.go:15:
                Error Trace:    C:/onebranch/fair/pkg/utils/time_utils_test.go:15
                Error:          Should be true
                Test:           TestClock

I believe this is because t1 and t2 happen closer together than the resolution of the clock so they evaluate as the same time, rather than one being later than the other.

This change allows t2 to be equal or greater than t1.

I didn't observe a failure in the second assert, but for consistency it seems reasonable to allow the delta to be exactly 10ms.