### PR TITLE
Remove single-threadedness coming from rotation lock

### DIFF
--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -26,7 +26,7 @@ type FairnessTracker struct {
 
 	// Rotation lock to ensure that we don't rotate while updating the structures
 	// The act of updating is a "read" in this case since multiple updates can happen
-	// concurrently but none can happend while we are rotating so that's a write.
+	// concurrently but none can happen while we are rotating so that's a write.
 	rotationLock *sync.RWMutex
 	stopRotation chan bool
 }


### PR DESCRIPTION
Using a single Mutex for all operations (updates and rotation) made all updates single threaded. This change addresses this problem using the RWMutex which treats updates as "reads" since they are allowed to happen concurrently and treats actual rotation as writes. Nothing can update while a rotation happens but multiple updates can happen at the same time while the rotation write lock is not held.

Addresses https://github.com/satmihir/fair/issues/5