### PR TITLE
Rename GetId to GetID

### DIFF
--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -79,7 +79,7 @@ func NewStructure(config *config.FairnessTrackerConfig, id uint64, includeStats 
 	return NewStructureWithClock(config, id, includeStats, utils.NewRealClock())
 }
 
-func (s *Structure) GetId() uint64 {
+func (s *Structure) GetID() uint64 {
 	return s.id
 }
 

--- a/pkg/data/data_test.go
+++ b/pkg/data/data_test.go
@@ -105,7 +105,7 @@ func TestHashes(t *testing.T) {
 	assert.Equal(t, hashes[2], hashes2[2])
 }
 
-func TestGetId(t *testing.T) {
+func TestGetID(t *testing.T) {
 	conf := &config.FairnessTrackerConfig{
 		L:  2,
 		M:  24,
@@ -116,7 +116,7 @@ func TestGetId(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, structure)
 
-	assert.Equal(t, int(structure.GetId()), 1)
+	assert.Equal(t, int(structure.GetID()), 1)
 }
 
 func TestEndToEnd(t *testing.T) {
@@ -132,7 +132,7 @@ func TestEndToEnd(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, structure)
 
-	assert.Equal(t, int(structure.GetId()), 1)
+	assert.Equal(t, int(structure.GetID()), 1)
 
 	ctx := context.Background()
 	id := []byte("hello_world")

--- a/pkg/request/type.go
+++ b/pkg/request/type.go
@@ -41,7 +41,7 @@ type ReportOutcomeResult struct{}
 // The data struecture interface
 type Tracker interface {
 	// Return the int ID of this structure. Used for implementing moving hashes.
-	GetId() uint64
+	GetID() uint64
 
 	// Register an incoming request from a client identified by a clientIdentifier
 	// The clientIdentifier needs to be unique and consistent for every client as

--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -53,9 +53,9 @@ func TestRotation(t *testing.T) {
 	assert.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
-		assert.Equal(t, int(trk.secondaryStructure.GetId()-trk.mainStructure.GetId()), 1)
+		assert.Equal(t, int(trk.secondaryStructure.GetID()-trk.mainStructure.GetID()), 1)
 		time.Sleep(1 * time.Second)
 	}
 
-	assert.True(t, trk.secondaryStructure.GetId() >= 2)
+	assert.True(t, trk.secondaryStructure.GetID() >= 2)
 }


### PR DESCRIPTION
This is a breaking change, but the package is in alpha.

The idea is to respect Go initialisms.

https://google.github.io/styleguide/go/decisions.html#initialisms
