### PR TITLE
golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@
 # Source: https://github.com/ccoVeille/golangci-lint-config-examples/
 # Author: @ccoVeille
 # License: MIT
-# Variant: 01-defaults
+# Variant: 03-safe
 # Version: v1.0.1
 #
 linters:
@@ -26,3 +26,131 @@ linters:
 
     # It's a set of rules from staticcheck. See https://staticcheck.io/
     - staticcheck
+
+    # Fast, configurable, extensible, flexible, and beautiful linter for Go.
+    # Drop-in replacement of golint.
+    - revive
+
+    # check imports order and makes it always deterministic.
+    - gci
+
+    # make sure to use t.Helper() when needed
+    - thelper
+
+    # mirror suggests rewrites to avoid unnecessary []byte/string conversion
+    - mirror
+
+    # detect the possibility to use variables/constants from the Go standard library.
+    - usestdlibvars
+
+    # Finds commonly misspelled English words.
+    - misspell
+
+    # Checks for duplicate words in the source code.
+    - dupword
+
+linters-settings:
+  gci:  # define the section orders for imports
+    sections:
+      # Standard section: captures all standard packages.
+      - standard
+      # Default section: catchall that is not standard or custom
+      - default
+      # linters that related to local tool, so they should be separated
+      - localmodule
+
+  revive:
+    rules:
+      # these are the default revive rules
+      # you can remove the whole "rules" node if you want
+      # BUT
+      # ! /!\ they all need to be present when you want to add more rules than the default ones
+      # otherwise, you won't have the default rules, but only the ones you define in the "rules" node
+
+      # Blank import should be only in a main or test package, or have a comment justifying it.
+      - name: blank-imports
+
+      # context.Context() should be the first parameter of a function when provided as argument.
+      - name: context-as-argument
+        arguments:
+          - allowTypesBefore: "*testing.T"
+
+      # Basic types should not be used as a key in `context.WithValue`
+      - name: context-keys-type
+
+      # Importing with `.` makes the programs much harder to understand
+      - name: dot-imports
+
+      # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
+      - name: empty-block
+
+      # for better readability, variables of type `error` must be named with the prefix `err`.
+      - name: error-naming
+
+      # for better readability, the errors should be last in the list of returned values by a function.
+      - name: error-return
+
+      # for better readability, error messages should not be capitalized or end with punctuation or a newline.
+      - name: error-strings
+
+      # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+      - name: errorf
+
+      # incrementing an integer variable by 1 is recommended to be done using the `++` operator
+      - name: increment-decrement
+
+      # highlights redundant else-blocks that can be eliminated from the code
+      - name: indent-error-flow
+
+      # This rule suggests a shorter way of writing ranges that do not use the second value.
+      - name: range
+
+      # receiver names in a method should reflect the struct name (p for Person, for example)
+      - name: receiver-naming
+
+      # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
+      - name: redefines-builtin-id
+
+      # redundant else-blocks that can be eliminated from the code.
+      - name: superfluous-else
+
+      # prevent confusing name for variables when using `time` package
+      - name: time-naming
+
+      # warns when an exported function or method returns a value of an un-exported type.
+      - name: unexported-return
+
+      # spots and proposes to remove unreachable code. also helps to spot errors
+      - name: unreachable-code
+
+      # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
+      - name: unused-parameter
+
+      # report when a variable declaration can be simplified
+      - name: var-declaration
+
+      # warns when initialism, variable or package naming conventions are not followed.
+      - name: var-naming
+
+  dupword:
+    # Keywords used to ignore detection.
+    # Default: []
+    ignore:
+    #  - "blah" # this will accept "blah blah …" as a valid duplicate word
+
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    # Default ("") is to use a neutral variety of English.
+    locale: US
+
+    # List of words to ignore
+    # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
+    ignore-words:
+    #  - valor
+    #  - and
+
+    # Extra word corrections.
+    extra-words:
+    #  - typo: "whattever"
+    #    correction: "whatever"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+---
+# golangci-lint configuration file made by @ccoVeille
+# Source: https://github.com/ccoVeille/golangci-lint-config-examples/
+# Author: @ccoVeille
+# License: MIT
+# Variant: 01-defaults
+# Version: v1.0.1
+#
+linters:
+  # some linters are enabled by default
+  # https://golangci-lint.run/usage/linters/
+  #
+  # enable some extra linters
+  enable:
+    # Errcheck is a program for checking for unchecked errors in Go code.
+    - errcheck
+
+    # Linter for Go source code that specializes in simplifying code.
+    - gosimple
+
+    # Vet examines Go source code and reports suspicious constructs.
+    - govet
+
+    # Detects when assignments to existing variables are not used.
+    - ineffassign
+
+    # It's a set of rules from staticcheck. See https://staticcheck.io/
+    - staticcheck

--- a/pkg/config/tuning.go
+++ b/pkg/config/tuning.go
@@ -85,7 +85,7 @@ func GenerateTunedStructureConfig(expectedClientFlows, bucketsPerLevel, tolerabl
 	}
 
 	// The probability to add per bad outcome so we fully block a flow after tolerable failures
-	var Pi float64 = 1 / float64(tolerableBadRequestsPerBadFlow)
+	Pi := 1 / float64(tolerableBadRequestsPerBadFlow)
 	// We want a slower recovery than the speed of marking workloads as bad
 	Pd := pdSlowingFactor * Pi
 

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -7,10 +7,11 @@ import (
 	"math/rand"
 	"sync"
 
+	"github.com/spaolacci/murmur3"
+
 	"github.com/satmihir/fair/pkg/config"
 	"github.com/satmihir/fair/pkg/request"
 	"github.com/satmihir/fair/pkg/utils"
-	"github.com/spaolacci/murmur3"
 )
 
 // Represents a bucket in the leveled structure

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -92,7 +92,7 @@ func (s *Structure) RegisterRequest(ctx context.Context, clientIdentifier []byte
 	bucketProbabilities := make([]float64, s.config.L)
 
 	// We can ignore the error since the handler never returns one
-	s.visitBuckets(clientIdentifier, func(l uint32, m uint32, b *bucket) error {
+	_ = s.visitBuckets(clientIdentifier, func(l uint32, m uint32, b *bucket) error {
 		bucketProbabilities[l] = b.probability
 		if s.includeStats {
 			if stats == nil {

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -87,7 +87,7 @@ func (s *Structure) GetID() uint64 {
 func (s *Structure) Close() {
 }
 
-func (s *Structure) RegisterRequest(ctx context.Context, clientIdentifier []byte) (*request.RegisterRequestResult, error) {
+func (s *Structure) RegisterRequest(_ context.Context, clientIdentifier []byte) (*request.RegisterRequestResult, error) {
 	var stats *request.ResultStats
 
 	bucketProbabilities := make([]float64, s.config.L)
@@ -125,13 +125,13 @@ func (s *Structure) RegisterRequest(ctx context.Context, clientIdentifier []byte
 	}, nil
 }
 
-func (s *Structure) ReportOutcome(ctx context.Context, clientIdentifier []byte, outcome request.Outcome) (*request.ReportOutcomeResult, error) {
+func (s *Structure) ReportOutcome(_ context.Context, clientIdentifier []byte, outcome request.Outcome) (*request.ReportOutcomeResult, error) {
 	adjustment := s.config.Pi
 	if outcome == request.OutcomeSuccess {
 		adjustment = -1 * s.config.Pd
 	}
 
-	err := s.visitBuckets(clientIdentifier, func(l uint32, m uint32, b *bucket) error {
+	err := s.visitBuckets(clientIdentifier, func(_ uint32, _ uint32, b *bucket) error {
 		p := b.probability + adjustment
 		if p < 0 {
 			p = 0

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -24,7 +24,7 @@ type bucket struct {
 	lock *sync.Mutex
 }
 
-func NewBucket(clock utils.IClock) *bucket {
+func newBucket(clock utils.IClock) *bucket {
 	return &bucket{
 		probability:           0,
 		lastUpdatedTimeMillis: uint64(clock.Now().UnixMilli()),
@@ -62,7 +62,7 @@ func NewStructureWithClock(config *config.FairnessTrackerConfig, id uint64, incl
 		levels[i] = make([]*bucket, config.M)
 
 		for j := 0; j < int(config.M); j++ {
-			levels[i][j] = NewBucket(clock)
+			levels[i][j] = newBucket(clock)
 		}
 	}
 

--- a/pkg/data/data_test.go
+++ b/pkg/data/data_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/satmihir/fair/pkg/config"
 	"github.com/satmihir/fair/pkg/request"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateStructConfig(t *testing.T) {

--- a/pkg/data/data_test.go
+++ b/pkg/data/data_test.go
@@ -142,7 +142,8 @@ func TestEndToEnd(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.False(t, resp.ShouldThrottle)
 
-	structure.ReportOutcome(ctx, id, request.OutcomeSuccess)
+	_, err = structure.ReportOutcome(ctx, id, request.OutcomeSuccess)
+	assert.NoError(t, err)
 
 	resp, err = structure.RegisterRequest(ctx, id)
 	assert.NoError(t, err)
@@ -150,7 +151,8 @@ func TestEndToEnd(t *testing.T) {
 	assert.False(t, resp.ShouldThrottle)
 
 	for i := 0; i < 1000; i++ {
-		structure.ReportOutcome(ctx, id, request.OutcomeFailure)
+		_, err = structure.ReportOutcome(ctx, id, request.OutcomeFailure)
+		assert.NoError(t, err)
 	}
 
 	resp, err = structure.RegisterRequest(ctx, id)

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -41,7 +41,7 @@ func (tb *TokenBucket) Take() error {
 	tb.tokens += tb.tokensPerSecond * float64(diff)
 
 	if tb.tokens >= 1 {
-		tb.tokens -= 1
+		tb.tokens--
 		return nil
 	}
 

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/satmihir/fair/pkg/request"
 	"github.com/satmihir/fair/pkg/tracker"
-	"github.com/stretchr/testify/assert"
 )
 
 var errNoTokens = fmt.Errorf("no tokens left")

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -83,10 +83,12 @@ func TestIntegration(t *testing.T) {
 
 				if err := tb.Take(); err != nil {
 					fourTwentyNine.Add(1)
-					trk.ReportOutcome(ctx, []byte(client), request.OutcomeFailure)
+					_, err = trk.ReportOutcome(ctx, []byte(client), request.OutcomeFailure)
+					assert.NoError(t, err)
 				} else {
 					twoHundred.Add(1)
-					trk.ReportOutcome(ctx, []byte(client), request.OutcomeSuccess)
+					_, err = trk.ReportOutcome(ctx, []byte(client), request.OutcomeSuccess)
+					assert.NoError(t, err)
 				}
 
 				time.Sleep(25 * time.Millisecond)

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestError(t *testing.T, expectedType interface{}, errInstance error, expectedMessage string, wrappedErr error) {
+	t.Helper()
+
 	_, ok := errInstance.(interface{ Unwrap() error })
 
 	assert.True(t, ok, "Error should be of expected type")

--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -17,7 +17,7 @@ type FairnessTracker struct {
 	trackerConfig *config.FairnessTrackerConfig
 
 	// A counter to uniquely identify a structure
-	structureIdCtr uint64
+	structureIDCounter uint64
 
 	mainStructure      request.Tracker
 	secondaryStructure request.Tracker
@@ -45,8 +45,8 @@ func NewFairnessTrackerWithClockAndTicker(trackerConfig *config.FairnessTrackerC
 
 	stopRotation := make(chan bool)
 	ft := &FairnessTracker{
-		trackerConfig:  trackerConfig,
-		structureIdCtr: 3,
+		trackerConfig:      trackerConfig,
+		structureIDCounter: 3,
 
 		mainStructure:      st1,
 		secondaryStructure: st2,
@@ -66,12 +66,12 @@ func NewFairnessTrackerWithClockAndTicker(trackerConfig *config.FairnessTrackerC
 			case <-stopRotation:
 				return
 			case <-ticker.C():
-				s, err := data.NewStructureWithClock(trackerConfig, ft.structureIdCtr, trackerConfig.IncludeStats, clock)
+				s, err := data.NewStructureWithClock(trackerConfig, ft.structureIDCounter, trackerConfig.IncludeStats, clock)
 				if err != nil {
 					// TODO: While this should never happen, think if we want to handle this more gracefully
 					log.Fatalf("Failed to create a structure during rotation")
 				}
-				ft.structureIdCtr++
+				ft.structureIDCounter++
 
 				ft.rotationLock.Lock()
 				ft.mainStructure = ft.secondaryStructure

--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/satmihir/fair/pkg/request"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/satmihir/fair/pkg/request"
 )
 
 func TestEndToEnd(t *testing.T) {

--- a/pkg/tracker/types_test.go
+++ b/pkg/tracker/types_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/satmihir/fair/pkg/config"
 	"github.com/satmihir/fair/pkg/testutils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFairnessTrackerError(t *testing.T) {

--- a/pkg/utils/time_utils_test.go
+++ b/pkg/utils/time_utils_test.go
@@ -26,7 +26,7 @@ func TestTicker(t *testing.T) {
 	select {
 	case <-ticker.C():
 		found = true
-		break
+	case <-time.After(100 * time.Millisecond):
 	}
 
 	assert.True(t, found)


### PR DESCRIPTION
- **Add minimal golangci-lint configuration**
- **Fix errors reported by errcheck linter**
- **Fix test that might never end if the ticker is not triggered**
- **enable more linters**
- **Fix import order by using gci configuration**
- **Avoid useless calls**
- **Fix TestError**
- **Remove method arguments when not used**
- **Rename variable**
- **Rename NewBucket to newBucket**

I used my own repository to enable progressively more and more linters
https://github.com/ccoVeille/golangci-lint-config-examples

Related to #4 