### PR TITLE
Fix token bucket time update

### DIFF
--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -37,8 +37,10 @@ func (tb *TokenBucket) Take() error {
 	tb.lk.Lock()
 	defer tb.lk.Unlock()
 
-	diff := (uint64(time.Now().UnixMilli()) - tb.lastUpdatedTimeMillis) / 1000
-	tb.tokens += tb.tokensPerSecond * float64(diff)
+	now := uint64(time.Now().UnixMilli())
+	diff := now - tb.lastUpdatedTimeMillis
+	tb.tokens += tb.tokensPerSecond * float64(diff) / 1000
+	tb.lastUpdatedTimeMillis = now
 
 	if tb.tokens >= 1 {
 		tb.tokens--


### PR DESCRIPTION
## Summary
- Corrected the token bucket’s Take method to update token count using elapsed milliseconds since the previous check and refresh the timestamp afterward

## Testing
- `go test ./...` *(fails: cannot download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6840a517b5e08329b2ae29eb94aa4e4c