### PR TITLE
Fix data race in tracker test

### DIFF
--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -50,9 +50,17 @@ func TestRotation(t *testing.T) {
 	assert.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
-		assert.Equal(t, int(trk.secondaryStructure.GetID()-trk.mainStructure.GetID()), 1)
+		trk.rotationLock.RLock()
+		diff := int(trk.secondaryStructure.GetID() - trk.mainStructure.GetID())
+		trk.rotationLock.RUnlock()
+
+		assert.Equal(t, diff, 1)
 		time.Sleep(1 * time.Second)
 	}
 
-	assert.True(t, trk.secondaryStructure.GetID() >= 2)
+	trk.rotationLock.RLock()
+	secID := trk.secondaryStructure.GetID()
+	trk.rotationLock.RUnlock()
+
+	assert.True(t, secID >= 2)
 }


### PR DESCRIPTION
## Summary
- avoid concurrent read/writes of `mainStructure`/`secondaryStructure` during rotation test by using `rotationLock`

## Testing
- `go test ./...`
- `go test -race ./...`


------
https://chatgpt.com/codex/tasks/task_e_684275e460788329b332d78c30dbc9bc