### PR TITLE
Improve idiomatic Go usage

### DIFF
--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -21,7 +21,7 @@ type TokenBucket struct {
 	tokensPerSecond       float64
 	lastUpdatedTimeMillis uint64
 
-	lk *sync.Mutex
+	lk sync.Mutex
 }
 
 func NewTokenBucket(initialTokens uint32, tokensPerSecond float64) *TokenBucket {
@@ -29,7 +29,6 @@ func NewTokenBucket(initialTokens uint32, tokensPerSecond float64) *TokenBucket 
 		tokens:                float64(initialTokens),
 		tokensPerSecond:       tokensPerSecond,
 		lastUpdatedTimeMillis: uint64(time.Now().UnixMilli()),
-		lk:                    &sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
## Summary
- embed `sync.Mutex` directly in bucket struct
- embed `sync.Mutex` in integration test token bucket
- simplify negative arithmetic when adjusting probability

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842773d7d648329937451f076541f11