### PR TITLE
Fix nil config handling

### DIFF
--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -36,6 +36,10 @@ type FairnessTracker struct {
 // provided clock and ticker. It is primarily used for tests and simulations
 // where time needs to be controlled.
 func NewFairnessTrackerWithClockAndTicker(trackerConfig *config.FairnessTrackerConfig, clock utils.IClock, ticker utils.ITicker) (*FairnessTracker, error) {
+	if trackerConfig == nil {
+		return nil, NewFairnessTrackerError(nil, "tracker configuration cannot be nil")
+	}
+
 	st1, err := data.NewStructureWithClock(trackerConfig, 1, trackerConfig.IncludeStats, clock)
 	if err != nil {
 		return nil, NewFairnessTrackerError(err, "Failed to create a structure")
@@ -90,6 +94,10 @@ func NewFairnessTrackerWithClockAndTicker(trackerConfig *config.FairnessTrackerC
 // NewFairnessTracker creates a FairnessTracker using the real system clock and
 // ticker.
 func NewFairnessTracker(trackerConfig *config.FairnessTrackerConfig) (*FairnessTracker, error) {
+	if trackerConfig == nil {
+		return nil, NewFairnessTrackerError(nil, "tracker configuration cannot be nil")
+	}
+
 	clk := utils.NewRealClock()
 	ticker := utils.NewRealTicker(trackerConfig.RotationFrequency)
 	return NewFairnessTrackerWithClockAndTicker(trackerConfig, clk, ticker)

--- a/pkg/tracker/types_test.go
+++ b/pkg/tracker/types_test.go
@@ -43,3 +43,10 @@ func TestBuildWithConfig(t *testing.T) {
 	assert.Equal(t, int(tr.trackerConfig.L), 4)
 	assert.Equal(t, int(tr.trackerConfig.M), 10)
 }
+
+func TestBuildWithNilConfig(t *testing.T) {
+	b := NewFairnessTrackerBuilder()
+	tr, err := b.BuildWithConfig(nil)
+	assert.Nil(t, tr)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- prevent panic when tracker config is nil
- test that building with nil config returns an error

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6843bc9a9bec8329afabe2387d08b0f4