### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,20 @@ You can use the `GenerateTunedStructureConfig` to tune the tracker without direc
 conf := config.GenerateTunedStructureConfig(1000, 1000, 25)
 trkB := tracker.NewFairnessTrackerBuilder()
 
-trk, err := trkB.BuildWithConfig(config)
+trk, err := trkB.BuildWithConfig(conf)
 defer trk.Close()
 ```
+
+## Development
+
+Run tests and static analysis locally with:
+
+```bash
+go test ./...
+golangci-lint run ./...
+```
+
+Ensure [golangci-lint](https://github.com/golangci/golangci-lint) is installed to execute the linter.
 
 ## Resources
 


### PR DESCRIPTION
## Summary
- fix config variable name in the tuning example
- add a Development section with instructions for running tests and linting

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: can't load config)*

------
https://chatgpt.com/codex/tasks/task_e_6843c49f7c04832993cadf2447cc420a