### PR TITLE
Add the zero handle and test for it

### DIFF
--- a/pkg/config/tuning.go
+++ b/pkg/config/tuning.go
@@ -93,6 +93,12 @@ func DefaultFairnessTrackerConfig() *FairnessTrackerConfig {
 //   - tolerableBadRequestsPerBadFlow: number of failed requests tolerated before
 //     a flow is fully blocked.
 func GenerateTunedStructureConfig(expectedClientFlows, bucketsPerLevel, tolerableBadRequestsPerBadFlow uint32) *FairnessTrackerConfig {
+	// If caller passes 0, fall back to the sane default and warn.
+    if tolerableBadRequestsPerBadFlow == 0 {
+        log.Printf("tolerableBadRequestsPerBadFlow=0 is invalid; falling back to default %d", defaultTolerableBadRequestsPerBadFlow)
+        tolerableBadRequestsPerBadFlow = defaultTolerableBadRequestsPerBadFlow
+    }
+	
 	M := uint32(math.Ceil(float64(expectedClientFlows) * percentBadClientFlows))
 	L := CalculateL(bucketsPerLevel, M, lowProbability)
 	if L < minL {

--- a/pkg/config/tuning_test.go
+++ b/pkg/config/tuning_test.go
@@ -27,3 +27,9 @@ func TestDefaultStructureConfig(t *testing.T) {
 	assert.Equal(t, conf.Pi*25, float64(1))
 	assert.Equal(t, conf.Pd*25*1000, float64(1))
 }
+
+func TestGenerateTunedStructureConfigZeroTolerable(t *testing.T) {
+    conf := GenerateTunedStructureConfig(1000, 1000, 0)
+    // Pi should be computed as 1 / defaultTolerableBadRequestsPerBadFlow
+    assert.Equal(t, conf.Pi*float64(defaultTolerableBadRequestsPerBadFlow), float64(1))
+}


### PR DESCRIPTION
## Description
Please include a summary of the changes and the related issue.  
Supplying tolerableBadRequestsPerBadFlow=0 to GenerateTunedStructureConfig currently causes a panic when computing Pi.  This PR tries to solve this. 

Code links: pkg/config/tuning.go#L79-L101
Fixes # (issue)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated related documentation
- [ ] I have added tests that prove my fix/feature works
