### PR TITLE
[FAIR-23] Add handling for nil tracker config

### DIFF
--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -90,6 +90,9 @@ func NewFairnessTrackerWithClockAndTicker(trackerConfig *config.FairnessTrackerC
 // NewFairnessTracker creates a FairnessTracker using the real system clock and
 // ticker.
 func NewFairnessTracker(trackerConfig *config.FairnessTrackerConfig) (*FairnessTracker, error) {
+	if trackerConfig == nil {
+		return nil, NewFairnessTrackerError(nil, "Configuration cannot be nil")
+	}
 	clk := utils.NewRealClock()
 	ticker := utils.NewRealTicker(trackerConfig.RotationFrequency)
 	return NewFairnessTrackerWithClockAndTicker(trackerConfig, clk, ticker)

--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"context"
+	"github.com/satmihir/fair/pkg/testutils"
 	"testing"
 	"time"
 
@@ -63,4 +64,21 @@ func TestRotation(t *testing.T) {
 	trk.rotationLock.RUnlock()
 
 	assert.True(t, secID >= 2)
+}
+
+func TestFairnessTrackerBuilder_BuildWithConfig(t *testing.T) {
+	trkB := NewFairnessTrackerBuilder()
+	trkDefault, err := trkB.BuildWithDefaultConfig()
+	assert.NoError(t, err)
+	defer trkDefault.Close()
+
+	trkWithNilConfig, errWithNilConfig := trkB.BuildWithConfig(nil)
+	assert.Error(t, errWithNilConfig)
+	testutils.TestError(t, &FairnessTrackerError{}, errWithNilConfig, "Configuration cannot be nil", nil)
+	assert.Nil(t, trkWithNilConfig)
+
+	trkWithNilConfig, errWithNilConfig = NewFairnessTracker(nil)
+	assert.Error(t, errWithNilConfig)
+	testutils.TestError(t, &FairnessTrackerError{}, errWithNilConfig, "Configuration cannot be nil", nil)
+	assert.Nil(t, trkWithNilConfig)
 }

--- a/pkg/tracker/types.go
+++ b/pkg/tracker/types.go
@@ -27,6 +27,9 @@ func (bl *FairnessTrackerBuilder) BuildWithDefaultConfig() (*FairnessTracker, er
 
 // BuildWithConfig builds a tracker using the supplied configuration.
 func (bl *FairnessTrackerBuilder) BuildWithConfig(configuration *config.FairnessTrackerConfig) (*FairnessTracker, error) {
+	if configuration == nil {
+		return nil, NewFairnessTrackerError(nil, "Configuration cannot be nil")
+	}
 	return NewFairnessTracker(configuration)
 }
 


### PR DESCRIPTION
## Description
Add explicit nil checks in both NewFairnessTracker and BuildWithConfig, so they return a wrapped FairnessTrackerError.

Fixes #23 

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated related documentation
- [x] I have added tests that prove my fix/feature works
