### PR TITLE
Fixed Issue#24

### DIFF
--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -36,6 +36,12 @@ type FairnessTracker struct {
 // provided clock and ticker. It is primarily used for tests and simulations
 // where time needs to be controlled.
 func NewFairnessTrackerWithClockAndTicker(trackerConfig *config.FairnessTrackerConfig, clock utils.IClock, ticker utils.ITicker) (*FairnessTracker, error) {
+	// Guard clause: fail fast and return a clear error when caller passes a nil config.
+	// Without this, the function dereferences fields on trackerConfig (e.g. trackerConfig.IncludeStats)
+	// below and will panic with "runtime error: invalid memory address or nil pointer dereference".
+	if trackerConfig == nil {
+		return nil, NewFairnessTrackerError(nil, "trackerConfig must not be nil")
+	}
 	st1, err := data.NewStructureWithClock(trackerConfig, 1, trackerConfig.IncludeStats, clock)
 	if err != nil {
 		return nil, NewFairnessTrackerError(err, "Failed to create a structure")

--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -82,3 +82,12 @@ func TestFairnessTrackerBuilder_BuildWithConfig(t *testing.T) {
 	testutils.TestError(t, &FairnessTrackerError{}, errWithNilConfig, "Configuration cannot be nil", nil)
 	assert.Nil(t, trkWithNilConfig)
 }
+func TestNewFairnessTrackerWithClockAndTicker_NilConfig(t *testing.T) {
+	// Passing a nil config should return an error rather than causing a panic.
+	ft, err := NewFairnessTrackerWithClockAndTicker(nil, nil, nil)
+
+	assert.Nil(t, ft)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "trackerConfig must not be nil")
+	}
+}


### PR DESCRIPTION
## Description
This PR added a guard clause: fail fast and return a clear error when caller passes a nil config i.e. if ```trackerConfig``` is nil then it prevents the reference like these ```trackerConfig.IncludeStats``` to break the system.

Fixes #24 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated related documentation
- [x] I have added tests that prove my fix/feature works
