### PR TITLE
Fixed #Issue25-rejects nil FairnessTrackerConfig and throws NewDataError

### DIFF
--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -185,6 +185,10 @@ func (s *Structure) currentMillis() uint64 {
 
 // Validate the input config against invariants
 func validateStructureConfig(config *config.FairnessTrackerConfig) error {
+	if config == nil {
+        return NewDataError(nil, "FairnessTrackerConfig cannot be nil")
+    }
+	
 	if config.L <= 0 || config.M <= 0 {
 		return fmt.Errorf("the values of L and M must be at least 1, found L: %d and M: %d", config.L, config.M)
 	}

--- a/pkg/data/data_test.go
+++ b/pkg/data/data_test.go
@@ -163,3 +163,16 @@ func TestAdjustProbability(t *testing.T) {
 	res := adjustProbability(0.90, .01, 10)
 	assert.Equal(t, res, 0.89991000449985)
 }
+//Explicitly test nil config case
+func TestValidateStructConfig_NilConfig(t *testing.T) {
+    err := validateStructureConfig(nil)
+
+    // Expect an error instead of panic
+    assert.Error(t, err)
+
+    // Ensure we wrapped it in DataError (consistent with other failures)
+    assert.IsType(t, &DataError{}, err)
+
+    // Error message should clearly state the root cause
+    assert.Contains(t, err.Error(), "cannot be nil")
+}


### PR DESCRIPTION
## Description
Please include a summary of the changes and the related issue.

Nil ```fairnessTrackerConfig``` if dereferenced can break the systems hence this fix aims at throwing a new data error if it finds ```fairnessTrackerConfig``` to be nil to prevent ```null pointer exception``` due to ```derefrencing```.  

Fixes #25 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated related documentation
- [x] I have added tests that prove my fix/feature works
