### PR TITLE
Fixed Issue#29:adding assert to verify rotation frequency matches val…

### DIFF
--- a/pkg/tracker/types_test.go
+++ b/pkg/tracker/types_test.go
@@ -33,6 +33,8 @@ func TestBuildFairnessTracker(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int(tr.trackerConfig.L), 10)
 	assert.Equal(t, int(tr.trackerConfig.M), 10)
+	assert.Equal(t, 1*time.Second, tr.trackerConfig.RotationFrequency,
+"rotation frequency should match the value set via builder")
 }
 
 func TestBuildWithConfig(t *testing.T) {


### PR DESCRIPTION
…ue set via builder

## Description
Please include a summary of the changes and the related issue.  

In TestBuildFairnessTracker the test sets SetRotationFrequency(1 * time.Second) but never verifies that this value is actually stored in the tracker’s config.

This CR aids this assertion below to solve this issue
assert.Equal(t, 1*time.Second, tr.trackerConfig.RotationFrequency,"rotation frequency should match the value set via builder")



Fixes #29 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated related documentation
- [x] I have added tests that prove my fix/feature works
