### PR TITLE
fix log.fatalF

### DIFF
--- a/pkg/config/tuning.go
+++ b/pkg/config/tuning.go
@@ -2,9 +2,10 @@ package config
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"time"
+
+	"github.com/satmihir/fair/pkg/logger"
 )
 
 const (
@@ -38,7 +39,7 @@ var (
 	// slice. It is the default implementation used by the tracker.
 	MinFinalProbabilityFunction FinalProbabilityFunction = func(buckets []float64) float64 {
 		if len(buckets) == 0 {
-			log.Fatalf("Cannot compute final probability with empty buckets slice")
+			logger.Fatalf("Cannot compute final probability with empty buckets slice")
 		}
 
 		var minVal float64 = 1.
@@ -54,7 +55,7 @@ var (
 	// too strict.
 	MeanFinalProbabilityFunction FinalProbabilityFunction = func(buckets []float64) float64 {
 		if len(buckets) == 0 {
-			log.Fatalf("Cannot compute final probability with empty buckets slice")
+			logger.Fatalf("Cannot compute final probability with empty buckets slice")
 		}
 
 		var total float64
@@ -75,7 +76,7 @@ func DefaultFairnessTrackerConfig() *FairnessTrackerConfig {
 		defaultTolerableBadRequestsPerBadFlow)
 	if err != nil {
 		// This should never happen with valid defaults
-		log.Fatalf("failed to generate default config: %v", err)
+		logger.Fatalf("failed to generate default config: %v", err)
 	}
 	return conf
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -10,7 +10,7 @@ type Logger interface {
 	Printf(format string, args ...any)
 	Print(args ...any)
 	Println(args ...any)
-	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
 }
 
 type noOpLogger struct{}
@@ -18,7 +18,7 @@ type noOpLogger struct{}
 func (n *noOpLogger) Printf(_ string, _ ...any) {}
 func (n *noOpLogger) Print(_ ...any)            {}
 func (n *noOpLogger) Println(_ ...any)          {}
-func (n *noOpLogger) Errorf(_ string, _ ...any) {}
+func (n *noOpLogger) Fatalf(_ string, _ ...any) {}
 
 var (
 	defaultNoOpLogger        = &noOpLogger{}
@@ -48,8 +48,8 @@ func (s *stdLogger) Println(args ...any) {
 	s.l.Println(args...)
 }
 
-func (s *stdLogger) Errorf(format string, args ...any) {
-	s.l.Printf("ERROR: "+format, args...)
+func (s *stdLogger) Fatalf(format string, args ...any) {
+	s.l.Fatalf(format, args...)
 }
 
 // Replaces default logger with provided logger
@@ -81,7 +81,7 @@ func Printf(format string, args ...any) {
 	GetLogger().Printf(format, args...)
 }
 
-// Errorf uses whichever logger is currently set
-func Errorf(format string, args ...any) {
-	GetLogger().Errorf(format, args...)
+// Fatalf uses whichever logger is currently set and panics after logging
+func Fatalf(format string, args ...any) {
+	GetLogger().Fatalf(format, args...)
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -30,8 +30,9 @@ func (t *testLogger) Println(args ...any) {
 	fmt.Println(args...)
 }
 
-func (t *testLogger) Errorf(format string, args ...any) {
-	fmt.Printf("ERROR: "+format, args...)
+func (t *testLogger) Fatalf(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	panic(msg)
 }
 
 func TestStdLogger_Print_VariousInputs(t *testing.T) {

--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -79,7 +79,7 @@ func NewFairnessTrackerWithClockAndTicker(trackerConfig *config.FairnessTrackerC
 			case <-ticker.C():
 				s, err := data.NewStructureWithClock(trackerConfig, ft.structureIDCounter, trackerConfig.IncludeStats, clock)
 				if err != nil {
-					logger.Errorf("failed to create a structure during rotation: %v", err)
+					logger.Fatalf("failed to create a structure during rotation: %v", err)
 					return
 				}
 				ft.structureIDCounter++


### PR DESCRIPTION
## Description

Error handling now uses `log.Fatalf` instead of `panic(fmt.Fatalf(...))` (this was incorrect) for reporting fatal errors, ensuring proper logging and program termination.

Fixes # (issue)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Design

## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated related documentation
- [ ] I have added tests that prove my fix/feature works
